### PR TITLE
Use a value that can evaluate successfully

### DIFF
--- a/src/argy-bargy.janet
+++ b/src/argy-bargy.janet
@@ -375,7 +375,8 @@
           (put pargs name (array/push (or (pargs name) @[]) val))
           (put pargs name val))
         (inc i))
-      (usage-error "'" arg "' is invalid value for " (string/ascii-upper name)))
+      (usage-error "'" (get args i) "' is an invalid value for "
+                   (string/ascii-upper name)))
     (usage-error "too many parameters passed")))
 
 


### PR DESCRIPTION
When reading source for jeep, a linter suggested that `arg` was not usuable in a [certain context](https://github.com/pyrmont/jeep/blob/1219041aeba7939ca20b2d39b6272e7f041b81c9/jeep/argy-bargy.janet#L373).  The line in question was in a copy of some version of `argy-bargy.janet` I suppose.

I guess `arg` is usable in the first branch of the `if-let` form below, but not in the second branch with the call to `usage-error`:

```janet
    (if-let [arg (get args i)
             val (convert arg (rule :value))]
      (do
        (if (rule :rest)
          (put pargs name (array/push (or (pargs name) @[]) val))
          (put pargs name val))
        (inc i))
      (usage-error "'" arg "' is invalid value for " (string/ascii-upper name)))
```

I don't know if the content in this PR is an appropriate remedy, but if it isn't may be something else appropriate can be done.