### PR TITLE
Windows tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.janet text eol=lf
+*.jdn text eol=lf
+*.cgen text eol=lf
+#
+*.gif binary
+*.jpg binary
+*.png binary

--- a/src/argy-bargy.janet
+++ b/src/argy-bargy.janet
@@ -20,7 +20,11 @@
   []
   (if (nil? cols)
     (do
-      (def p (os/spawn ["tput" "cols"] :p {:out :pipe :err :pipe}))
+      (def cmd
+        (if (= :windows (os/which))
+          ["powershell" "-command" "&{(get-host).ui.rawui.WindowSize.Width;}"]
+          ["tput" "cols"]))
+      (def p (os/spawn cmd :p {:out :pipe :err :pipe}))
       (def err (:wait p))
       (def tcols (when (zero? err) (-> (p :out) (:read :all) string/trim scan-number)))
       (min (or tcols max-width) max-width))


### PR DESCRIPTION
This PR is an attempt to improve support for Windows.

The changes it contains include:

* Use of powershell to obtain a value for columns of the terminal [1]
* Addition of `.gitattributes` to ensure that the test file content is not altered by git on Windows to contain CRs (carriage returns)

With these changes, all tests pass on a Windows 10 box locally.

Note that if one has already cloned argy-bargy to Windows (without an appropriate `.gitattributes` file or configuration to address the EOL situation), just switching branches to a branch with an appopriate `.gitattributes` file does not appear to affect existing files that already have CRs in them.  That is, files don't get fixed by switching branches AFAICT.

I do not know why that is, but a work-around is to reclone the repository -- to / with (?) a branch that does have an appropriate `.gitattributes` file.

---

[1] I ran `jpm test` via both `cmd.exe` and powershell successfully.